### PR TITLE
Detritus compatibility fix

### DIFF
--- a/action.php
+++ b/action.php
@@ -38,10 +38,10 @@ class action_plugin_securelogin extends DokuWiki_Action_Plugin {
 		if(!$this->slhlp || !$this->slhlp->canWork() || !$this->slhlp->haveKey(true)) return;
 		
 		if(isset($_REQUEST['use_securelogin']) && $_REQUEST['use_securelogin'] && isset($_REQUEST['securelogin'])) {
-			list($request,) = split(';', $this->slhlp->decrypt($_REQUEST['securelogin']));
+			list($request,) = explode(';', $this->slhlp->decrypt($_REQUEST['securelogin']));
 			if($request) {
-				foreach(split("&", $request) as $var) {
-					list($key, $value) = split("=",$var,2);
+				foreach(explode("&", $request) as $var) {
+					list($key, $value) = explode("=",$var,2);
 					$value = urldecode($value);
 					$_REQUEST[$key] = $value;
 					$_POST[$key] = $value;

--- a/action.php
+++ b/action.php
@@ -5,10 +5,10 @@ require_once(DOKU_PLUGIN.'action.php');
 require_once(DOKU_INC.'inc/form.php');
 
 class action_plugin_securelogin extends DokuWiki_Action_Plugin {
-	var $slhlp;
+	protected $slhlp;
 
-	function action_plugin_securelogin () {
-		$this->slhlp =& plugin_load('helper', $this->getPluginName());
+	function __construct() {
+		$this->slhlp = plugin_load('helper', $this->getPluginName());
 	}
 	
 	/**

--- a/action.php
+++ b/action.php
@@ -28,12 +28,12 @@ class action_plugin_securelogin extends DokuWiki_Action_Plugin {
 	/**
 	 * Register its handlers with the DokuWiki's event controller
 	 */
-	function register(&$controller) {
+	function register(Doku_Event_Handler $controller) {
 		$controller->register_hook('AUTH_LOGIN_CHECK', 'BEFORE',  $this, '_auth');
 		$controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE',  $this, '_ajax_handler');
 	}
 	
-	function _auth(&$event, $param) {
+	function _auth(Doku_Event $event, $param) {
 		$this->slhlp->workCorrect(true);
 		if(!$this->slhlp || !$this->slhlp->canWork() || !$this->slhlp->haveKey(true)) return;
 		
@@ -56,7 +56,7 @@ class action_plugin_securelogin extends DokuWiki_Action_Plugin {
 		}
 	}
 	
-	function _ajax_handler(&$event, $param) {
+	function _ajax_handler(Doku_Event $event, $param) {
 		if($event->data != 'securelogin_public_key') return;
 		if(!$this->slhlp || !$this->slhlp->canWork() || !$this->slhlp->haveKey(true)) return;
 		

--- a/action.php
+++ b/action.php
@@ -12,60 +12,60 @@
 if(!defined('DOKU_INC')) die();
 
 class action_plugin_securelogin extends DokuWiki_Action_Plugin {
-	protected $slhlp;
+    protected $slhlp;
 
-	function __construct() {
-		$this->slhlp = plugin_load('helper', $this->getPluginName());
-	}
+    function __construct() {
+        $this->slhlp = plugin_load('helper', $this->getPluginName());
+    }
 
-	/**
-	 * Register its handlers with the DokuWiki's event controller
-	 */
-	function register(Doku_Event_Handler $controller) {
-		$controller->register_hook('AUTH_LOGIN_CHECK', 'BEFORE',  $this, '_auth');
-		$controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE',  $this, '_ajax_handler');
-	}
-	
-	function _auth(Doku_Event $event, $param) {
-		$this->slhlp->workCorrect(true);
-		if(!$this->slhlp || !$this->slhlp->canWork() || !$this->slhlp->haveKey(true)) return;
-		
-		if(isset($_REQUEST['use_securelogin']) && $_REQUEST['use_securelogin'] && isset($_REQUEST['securelogin'])) {
-			list($request,) = explode(';', $this->slhlp->decrypt($_REQUEST['securelogin']));
-			if($request) {
-				foreach(explode("&", $request) as $var) {
-					list($key, $value) = explode("=",$var,2);
-					$value = urldecode($value);
-					$_REQUEST[$key] = $value;
-					$_POST[$key] = $value;
-				}
-			}
-			unset($_REQUEST['securelogin']);
-			unset($_REQUEST['use_securelogin']);
-		}
-		if($_REQUEST['do'] == "login") {
-			auth_login($_REQUEST['u'], $_REQUEST['p'], $_REQUEST['r'], $_REQUEST['http_credentials']);
-			$event->preventDefault();
-		}
-	}
-	
-	function _ajax_handler(Doku_Event $event, $param) {
-		if($event->data != 'securelogin_public_key') return;
-		if(!$this->slhlp || !$this->slhlp->canWork() || !$this->slhlp->haveKey(true)) return;
-		
-		header('Content-Type: text/javascript; charset=utf-8');
-		print 'function encrypt(text) {
+    /**
+     * Register its handlers with the DokuWiki's event controller
+     */
+    function register(Doku_Event_Handler $controller) {
+        $controller->register_hook('AUTH_LOGIN_CHECK', 'BEFORE',  $this, '_auth');
+        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE',  $this, '_ajax_handler');
+    }
+
+    function _auth(Doku_Event $event, $param) {
+        $this->slhlp->workCorrect(true);
+        if(!$this->slhlp || !$this->slhlp->canWork() || !$this->slhlp->haveKey(true)) return;
+        
+        if(isset($_REQUEST['use_securelogin']) && $_REQUEST['use_securelogin'] && isset($_REQUEST['securelogin'])) {
+            list($request,) = explode(';', $this->slhlp->decrypt($_REQUEST['securelogin']));
+            if($request) {
+                foreach(explode("&", $request) as $var) {
+                    list($key, $value) = explode("=",$var,2);
+                    $value = urldecode($value);
+                    $_REQUEST[$key] = $value;
+                    $_POST[$key] = $value;
+                }
+            }
+            unset($_REQUEST['securelogin']);
+            unset($_REQUEST['use_securelogin']);
+        }
+        if($_REQUEST['do'] == "login") {
+            auth_login($_REQUEST['u'], $_REQUEST['p'], $_REQUEST['r'], $_REQUEST['http_credentials']);
+            $event->preventDefault();
+        }
+    }
+
+    function _ajax_handler(Doku_Event $event, $param) {
+        if($event->data != 'securelogin_public_key') return;
+        if(!$this->slhlp || !$this->slhlp->canWork() || !$this->slhlp->haveKey(true)) return;
+
+        header('Content-Type: text/javascript; charset=utf-8');
+        print 'function encrypt(text) {
         var rsa = new RSAKey();
         rsa.setPublic("'.$this->slhlp->getModulus().'", "'.$this->slhlp->getExponent().'");
         var res = rsa.encrypt(text);
         if(res) {
                 return hex2b64(res);
         }
-		}
-		var securelogin_login_label = "'.$this->getLang('use_securelogin').'";
-		var securelogin_update_label = "'.$this->getLang('use_secureupdate').'";';
-		
-		$event->preventDefault();
-		return;
-	}
+        }
+        var securelogin_login_label = "'.$this->getLang('use_securelogin').'";
+        var securelogin_update_label = "'.$this->getLang('use_secureupdate').'";';
+
+        $event->preventDefault();
+        return;
+    }
 }

--- a/action.php
+++ b/action.php
@@ -1,8 +1,15 @@
-<?php 
+<?php
+/**
+ * Action Component for Securelogin Dokuwiki Plugin
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Mikhail I. Izmestev, Matt Bagley <securelogin@mattfiddles.com>
+ *
+ * @see also   https://www.dokuwiki.org/plugin:securelogin
+ */
+
+// must be run within Dokuwiki
 if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'action.php');
-require_once(DOKU_INC.'inc/form.php');
 
 class action_plugin_securelogin extends DokuWiki_Action_Plugin {
 	protected $slhlp;
@@ -10,21 +17,7 @@ class action_plugin_securelogin extends DokuWiki_Action_Plugin {
 	function __construct() {
 		$this->slhlp = plugin_load('helper', $this->getPluginName());
 	}
-	
-	/**
-	 * return some info
-	 */
-	function getInfo(){
-		return array(
-            'author' => 'Mikhail I. Izmestev, Matt Bagley',
-            'email'  => 'securelogin@mattfiddles.com',
-            'date'   => '2014-09-23',
-            'name'   => 'Securelogin Plugin',
-            'desc'   => 'This plugin lets you login securely without HTTPS by sending your password in encrypted form to the server.',
-            'url'    => 'http://www.dokuwiki.org/plugin:securelogin',
-		);
-	}
-	
+
 	/**
 	 * Register its handlers with the DokuWiki's event controller
 	 */

--- a/admin.php
+++ b/admin.php
@@ -1,8 +1,15 @@
 <?php
-if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'admin.php');
-require_once(DOKU_INC.'inc/form.php');
+/**
+ * Adminn Component for Securelogin Dokuwiki Plugin
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Mikhail I. Izmestev, Matt Bagley <securelogin@mattfiddles.com>
+ *
+ * @see also   https://www.dokuwiki.org/plugin:securelogin
+ */
+
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
 
 /**
  * All DokuWiki plugins to extend the admin function
@@ -15,21 +22,7 @@ class admin_plugin_securelogin extends DokuWiki_Admin_Plugin {
 		$this->slhlp = plugin_load('helper', $this->getPluginName());
 		if(!$this->slhlp) msg('Loading the '.$this->getPluginName().' helper failed. Make sure that the '.$this->getPluginName().' plugin is installed.', -1);
 	}
-	
-	/**
-	 * return some info
-	 */
-	function getInfo(){
-		return array(
-            'author' => 'Mikhail I. Izmestev, Matt Bagley',
-            'email'  => 'securelogin@mattfiddles.com',
-            'date'   => '2014-09-23',
-            'name'   => 'Securelogin Plugin',
-            'desc'   => 'This plugin lets you login securely without HTTPS by sending your password in encrypted form to the server.',
-            'url'    => 'http://www.dokuwiki.org/plugin:securelogin',
-		);
-	}
-	
+
 	/**
 	 * return sort order for position in admin menu
 	 */
@@ -113,4 +106,3 @@ class admin_plugin_securelogin extends DokuWiki_Admin_Plugin {
 		html_form('test__publicKey', $form);
 	}
 }
-?>

--- a/admin.php
+++ b/admin.php
@@ -16,93 +16,93 @@ if(!defined('DOKU_INC')) die();
  * need to inherit from this class
  */
 class admin_plugin_securelogin extends DokuWiki_Admin_Plugin {
-	protected $slhlp = null;
-	
-	function __construct() {
-		$this->slhlp = plugin_load('helper', $this->getPluginName());
-		if(!$this->slhlp) msg('Loading the '.$this->getPluginName().' helper failed. Make sure that the '.$this->getPluginName().' plugin is installed.', -1);
-	}
+    protected $slhlp = null;
 
-	/**
-	 * return sort order for position in admin menu
-	 */
-	function getMenuSort() {
-		return 999;
-	}
+    function __construct() {
+        $this->slhlp = plugin_load('helper', $this->getPluginName());
+        if(!$this->slhlp) msg('Loading the '.$this->getPluginName().' helper failed. Make sure that the '.$this->getPluginName().' plugin is installed.', -1);
+    }
 
-	function getMenuText($lang) {
-		return $this->getLang('securelogin_conf');
-	}
-	
-	/**
-	 * handle user request
-	 */
-	function handle() {
-		if(!$this->slhlp->canWork())
-			msg("You need openssl php module for this plugin work!", -1);
-		elseif($this->slhlp->haveKey() && !$this->slhlp->workCorrect())
-			msg("Your version of dokuwiki not generate AUTH_LOGIN_CHECK event, plugin not work!");
-			
-		$fn = $_REQUEST['fn'];
-		
-		if (is_array($fn)) {
-			$cmd = key($fn);
-			$param = $fn[$cmd];
-		} else {
-			$cmd = $fn;
-			$param = null;
-		}
-		
-		switch($cmd) {
-			case "newkey":	$this->slhlp->generateKey($param); break;
-			case "test":	msg(urldecode($this->slhlp->decrypt($param['message']))); break;
-		}
-	}
-	
-	/**
-	 * output appropriate html
-	 */
-	function html() {
-		if(!$this->slhlp->canWork()) {
-			print $this->locale_xhtml('needopenssl');
-			return;
-		}
-		elseif($this->slhlp->haveKey() && !$this->slhlp->workCorrect())
-			print $this->locale_xhtml('needpatch');
-		ptln('<div id="secure__login">');
-		$this->_html_generateKey();
-		
-		if($this->slhlp->haveKey()) {
-			$this->_html_test();
-	
-//			print $this->render("===== ".$this->getLang('public_key')." ===== \n".
-//					"<code>\n".
-//					$this->slhlp->getPublicKey().
-//					"</code>",
-//					$format='xhtml');
-		}
-		ptln('</div>');
-	}
-	
-	function _html_generateKey() {
-		global $ID;
-		$form = new Doku_Form('generate__key', wl($ID,'do=admin,page='.$this->getPluginName(), false, '&'));
-		$form->startFieldset($this->getLang('generate_key'));
-		$form->addElement(form_makeMenuField('fn[newkey]', $this->slhlp->getKeyLengths(), $this->slhlp->getKeyLength(), $this->getLang('key_length'), 'key__length', 'block', array('class' => 'edit')));
-		$form->addElement(form_makeButton('submit', '', $this->getLang('generate')));
-		$form->endFieldset();
-		ptln('<div class="half">');
-		html_form('generate', $form);
-		ptln('</div>');
-	}
-	
-	function _html_test() {
-		global $ID;
-		$form = new Doku_Form('test__publicKey', wl($ID,'do=admin,page='.$this->getPluginName(), false, '&'));
-		$form->startFieldset($this->getLang('test_key'));
-		$form->addElement(form_makeTextField('fn[test][message]', $this->getLang('sample_message'), $this->getLang('test_message'), 'test__message', 'block'));
-		$form->addElement(form_makeButton('submit', '', $this->getLang('test')));
-		$form->endFieldset();
-		html_form('test__publicKey', $form);
-	}
+    /**
+     * return sort order for position in admin menu
+     */
+    function getMenuSort() {
+        return 999;
+    }
+
+    function getMenuText($lang) {
+        return $this->getLang('securelogin_conf');
+    }
+
+    /**
+     * handle user request
+     */
+    function handle() {
+        if(!$this->slhlp->canWork())
+            msg("You need openssl php module for this plugin work!", -1);
+        elseif($this->slhlp->haveKey() && !$this->slhlp->workCorrect())
+            msg("Your version of dokuwiki not generate AUTH_LOGIN_CHECK event, plugin not work!");
+
+        $fn = $_REQUEST['fn'];
+
+        if (is_array($fn)) {
+            $cmd = key($fn);
+            $param = $fn[$cmd];
+        } else {
+            $cmd = $fn;
+            $param = null;
+        }
+
+        switch($cmd) {
+            case "newkey": $this->slhlp->generateKey($param); break;
+            case "test": msg(urldecode($this->slhlp->decrypt($param['message']))); break;
+        }
+    }
+
+    /**
+     * output appropriate html
+     */
+    function html() {
+        if(!$this->slhlp->canWork()) {
+            print $this->locale_xhtml('needopenssl');
+            return;
+        }
+        elseif($this->slhlp->haveKey() && !$this->slhlp->workCorrect())
+            print $this->locale_xhtml('needpatch');
+        ptln('<div id="secure__login">');
+        $this->_html_generateKey();
+
+        if($this->slhlp->haveKey()) {
+            $this->_html_test();
+
+//      print $this->render("===== ".$this->getLang('public_key')." ===== \n".
+//          "<code>\n".
+//          $this->slhlp->getPublicKey().
+//          "</code>",
+//          $format='xhtml');
+        }
+        ptln('</div>');
+    }
+
+    function _html_generateKey() {
+        global $ID;
+        $form = new Doku_Form('generate__key', wl($ID,'do=admin,page='.$this->getPluginName(), false, '&'));
+        $form->startFieldset($this->getLang('generate_key'));
+        $form->addElement(form_makeMenuField('fn[newkey]', $this->slhlp->getKeyLengths(), $this->slhlp->getKeyLength(), $this->getLang('key_length'), 'key__length', 'block', array('class' => 'edit')));
+        $form->addElement(form_makeButton('submit', '', $this->getLang('generate')));
+        $form->endFieldset();
+        ptln('<div class="half">');
+        html_form('generate', $form);
+        ptln('</div>');
+    }
+
+    function _html_test() {
+        global $ID;
+        $form = new Doku_Form('test__publicKey', wl($ID,'do=admin,page='.$this->getPluginName(), false, '&'));
+        $form->startFieldset($this->getLang('test_key'));
+        $form->addElement(form_makeTextField('fn[test][message]', $this->getLang('sample_message'), $this->getLang('test_message'), 'test__message', 'block'));
+        $form->addElement(form_makeButton('submit', '', $this->getLang('test')));
+        $form->endFieldset();
+        html_form('test__publicKey', $form);
+    }
 }

--- a/admin.php
+++ b/admin.php
@@ -9,10 +9,10 @@ require_once(DOKU_INC.'inc/form.php');
  * need to inherit from this class
  */
 class admin_plugin_securelogin extends DokuWiki_Admin_Plugin {
-	var $slhlp = null;
+	protected $slhlp = null;
 	
-	function admin_plugin_securelogin () {
-		$this->slhlp =& plugin_load('helper', $this->getPluginName());
+	function __construct() {
+		$this->slhlp = plugin_load('helper', $this->getPluginName());
 		if(!$this->slhlp) msg('Loading the '.$this->getPluginName().' helper failed. Make sure that the '.$this->getPluginName().' plugin is installed.', -1);
 	}
 	

--- a/helper.php
+++ b/helper.php
@@ -1,10 +1,14 @@
 <?php
+/**
+ * Helper Component for Securelogin Dokuwiki Plugin
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Mikhail I. Izmestev, Matt Bagley <securelogin@mattfiddles.com>
+ *
+ * @see also   https://www.dokuwiki.org/plugin:securelogin
+ */
 // must be run within Dokuwiki
 if(!defined('DOKU_INC')) die();
-
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_INC.'inc/infoutils.php');
-
 
 /**
  * This is the base class for all syntax classes, providing some general stuff
@@ -39,20 +43,6 @@ class helper_plugin_securelogin extends DokuWiki_Plugin {
 		return $this->_canWork;
 	}
 
-	/**
-	 * return some info
-	 */
-	function getInfo(){
-		return array(
-            'author' => 'Mikhail I. Izmestev, Matt Bagley',
-            'email'  => 'securelogin@mattfiddles.com',
-            'date'   => '2014-09-23',
-            'name'   => 'Securelogin Plugin',
-            'desc'   => 'This plugin lets you login securely without HTTPS by sending your password in encrypted form to the server.',
-            'url'    => 'http://www.dokuwiki.org/plugin:securelogin',
-		);
-	}
-	
 	function haveKey($onlyPublic = false) {
 		if($onlyPublic) {
 			if($this->_keyInfo)	return true;
@@ -225,4 +215,3 @@ class helper_plugin_securelogin extends DokuWiki_Plugin {
 		return $this->_workCorrect;
 	}
 }
-?>

--- a/helper.php
+++ b/helper.php
@@ -14,204 +14,200 @@ if(!defined('DOKU_INC')) die();
  * This is the base class for all syntax classes, providing some general stuff
  */
 class helper_plugin_securelogin extends DokuWiki_Plugin {
-	protected $_keyFile;
-	protected $_keyIFile;
-	protected $_key = null;
-	protected $_keyInfo = null;
-	protected $_workCorrect = false;
-	protected $_canWork = false;
-	
-	/**
-	 * constructor
-	 */
-	function __construct() {
-		global $conf;
+    protected $_keyFile;
+    protected $_keyIFile;
+    protected $_key = null;
+    protected $_keyInfo = null;
+    protected $_workCorrect = false;
+    protected $_canWork = false;
 
-		$this->_keyIFile = $conf['cachedir'].'/securelogin.ini';
-		$this->_keyFile = $conf['cachedir'].'/securelogin.key';
+    /**
+     * constructor
+     */
+    function __construct() {
+        global $conf;
 
-		if( true 
-			&& function_exists("openssl_pkey_export_to_file")
-			&& function_exists("openssl_pkey_get_private")
-			&& function_exists("openssl_pkey_new")
-			&& function_exists("openssl_private_decrypt")
-			)
-			$this->_canWork = true;
-	}
-	
-	function canWork() {
-		return $this->_canWork;
-	}
+        $this->_keyIFile = $conf['cachedir'].'/securelogin.ini';
+        $this->_keyFile = $conf['cachedir'].'/securelogin.key';
 
-	function haveKey($onlyPublic = false) {
-		if($onlyPublic) {
-			if($this->_keyInfo)	return true;
+        if( true 
+            && function_exists("openssl_pkey_export_to_file")
+            && function_exists("openssl_pkey_get_private")
+            && function_exists("openssl_pkey_new")
+            && function_exists("openssl_private_decrypt")
+            )
+            $this->_canWork = true;
+    }
 
-			if(file_exists($this->_keyIFile)) {
-				$this->_keyInfo = parse_ini_file($this->_keyIFile);
-				return true;
-			}
-		}
-		
-		if(!$this->_key && file_exists($this->_keyFile)) {
-			$this->_key = openssl_pkey_get_private(file_get_contents($this->_keyFile));
-			if($this->_key) {
-				if(file_exists($this->_keyIFile))
-					$this->_keyInfo = parse_ini_file($this->_keyIFile);
-				else
-					$this->savePublicInfo($this->getPublicKeyInfo(file_get_contents($this->_keyFile)));
-			}
-		}
-		return null != $this->_key;
-	}
-	
-	function getKeyLengths() {
-		return array('default' => 'default', '512' => '512', '1024' => '1024', '2048' => '2048');
-	}
-	
-	function generateKey($length) {
-		if(!array_key_exists($length, $this->getKeyLengths())) {
-			msg("Error key length $length not supported", -1);
-			return;
-		}
-		
-		$newkey = @openssl_pkey_new(('default' == $length)?array():array('private_key_bits' => intval($length)));
+    function canWork() {
+        return $this->_canWork;
+    }
 
-		if(!$newkey) {
-			msg('Error generating new key', -1);
-			return; 
-		}
-		if(!openssl_pkey_export_to_file($newkey, $this->_keyFile))
-			msg('Error export new key', -1);
-		else {
-			$this->_key = openssl_pkey_get_private(file_get_contents($this->_keyFile));
-			$this->savePublicInfo($this->getPublicKeyInfo(file_get_contents($this->_keyFile)));
-		}
-	}
-	
-	function getKeyLength() {
-		return (strlen($this->getModulus())-2)*4;
-	}
-	
-	function getModulus() {
-		return ($this->haveKey(true))?$this->_keyInfo['modulus']:null;
-	}
-	
-	function getExponent() {
-		return ($this->haveKey(true))?$this->_keyInfo['exponent']:null;
-	}
-	
-	function savePublicInfo($info) {
-		$fpinfo = fopen($this->_keyIFile, "w");
-		foreach($info as $key => $val) {
-			fprintf($fpinfo, "%s=\"%s\"\n", $key, $val);
-		}
-		fclose($fpinfo);
-		$this->_keyInfo = parse_ini_file($this->_keyIFile);
-	}
-	
-	function decrypt($text) {
-		if($this->haveKey())
-			openssl_private_decrypt(base64_decode($text), $decoded, $this->_key);
-		return $decoded;
-	}
-		
-	function decodeBER($bin) {
-		function my_unpack($format, &$bin, $length) {
-			$res = unpack($format, $bin);
-			$bin = substr($bin, $length);
-			return $res;
-		}	
-		
-		function readBER(&$bin) {
-			if(!strlen($bin)) return FALSE;
-			
-			
-			$data = my_unpack("C1type/c1length", $bin, 2);
-			
-			if($data[length] < 0) {
-				$count = $data[length] & 0x7F;
-				$data[length] = 0;
-				while($count) {
-					 $data[length] <<= 8;
-					 $tmp = my_unpack("C1length", $bin, 1);
-					 $data[length] += $tmp[length];
-					 $count--;
-				}
-			}
-			
-			switch($data[type]) {
-				case 0x30:	
-					$data[value] = array();
-					do {
-						$tmp = readBER($bin);
-						if($tmp)
-							$data[value][] = $tmp; 
-					} while($tmp);
-					break;
-				case 0x03:
-					$null = my_unpack("C1", $bin, 1);
-					$data[value] = readBER($bin);
-					break;
-				case 0x04:
-					$data[value] = readBER($bin);
-					break;
-				default: 
-					$count = $data[length];
-					while($count) {
-						$tmp = my_unpack("C1data", $bin, 1);
-						$data[value] .= sprintf("%02X", $tmp[data]);
-						$count--;
-					}
-			}
-			
-			return $data;
-		}
-		
-		return readBER($bin); 
-	}
-	
-	function getPublicKeyInfo($pubkey) {
-		function findKeyInfo($data, &$pubkeyinfo) {
-			if($data[type] == 48) {
-				if(count($data[value]) != 9) {
-					foreach($data[value] as $subdata) {
-						if(findKeyInfo($subdata, $pubkeyinfo))
-							return true;
-					}
-				}
-				else {
-					$pubkeyinfo = array(
-						"modulus" => $data[value][1][value],
-						"exponent" => $data[value][2][value],
-					);
-					return true;
-				}
-			}
-			elseif($data[type] == 4) {
-				return findKeyInfo($data[value], $pubkeyinfo);
-			}
-			return false;
-		}
+    function haveKey($onlyPublic = false) {
+        if($onlyPublic) {
+            if($this->_keyInfo) return true;
 
-		$pubkey = preg_split("(-\n|\n-)", $pubkey);
-		$binary = base64_decode($pubkey[1]);
-		
-		$data = $this->decodeBER($binary);
-		
-		findKeyInfo($data, $pubkeyinfo);
-/*		
-		$pubkeyinfo = array(
-			"modulus" => $data[value][1][value][2][value][value][1][value],
-			"exponent" => $data[value][1][value][2][value][value][2][value],
-		);
-*/		
-		return $pubkeyinfo;	
-	}
-	
-	function workCorrect($yes = false) {
-		if($yes)
-			$this->_workCorrect = true;
-		return $this->_workCorrect;
-	}
+            if(file_exists($this->_keyIFile)) {
+                $this->_keyInfo = parse_ini_file($this->_keyIFile);
+                return true;
+            }
+        }
+
+        if(!$this->_key && file_exists($this->_keyFile)) {
+            $this->_key = openssl_pkey_get_private(file_get_contents($this->_keyFile));
+            if($this->_key) {
+                if(file_exists($this->_keyIFile))
+                    $this->_keyInfo = parse_ini_file($this->_keyIFile);
+                else
+                    $this->savePublicInfo($this->getPublicKeyInfo(file_get_contents($this->_keyFile)));
+            }
+        }
+        return null != $this->_key;
+    }
+
+    function getKeyLengths() {
+        return array('default' => 'default', '512' => '512', '1024' => '1024', '2048' => '2048');
+    }
+
+    function generateKey($length) {
+        if(!array_key_exists($length, $this->getKeyLengths())) {
+            msg("Error key length $length not supported", -1);
+            return;
+        }
+
+        $newkey = @openssl_pkey_new(('default' == $length)?array():array('private_key_bits' => intval($length)));
+
+        if(!$newkey) {
+            msg('Error generating new key', -1);
+            return; 
+        }
+        if(!openssl_pkey_export_to_file($newkey, $this->_keyFile))
+            msg('Error export new key', -1);
+        else {
+            $this->_key = openssl_pkey_get_private(file_get_contents($this->_keyFile));
+            $this->savePublicInfo($this->getPublicKeyInfo(file_get_contents($this->_keyFile)));
+        }
+    }
+
+    function getKeyLength() {
+        return (strlen($this->getModulus())-2)*4;
+    }
+
+    function getModulus() {
+        return ($this->haveKey(true))?$this->_keyInfo['modulus']:null;
+    }
+
+    function getExponent() {
+        return ($this->haveKey(true))?$this->_keyInfo['exponent']:null;
+    }
+
+    function savePublicInfo($info) {
+        $fpinfo = fopen($this->_keyIFile, "w");
+        foreach($info as $key => $val) {
+            fprintf($fpinfo, "%s=\"%s\"\n", $key, $val);
+        }
+        fclose($fpinfo);
+        $this->_keyInfo = parse_ini_file($this->_keyIFile);
+    }
+
+    function decrypt($text) {
+        if($this->haveKey())
+            openssl_private_decrypt(base64_decode($text), $decoded, $this->_key);
+        return $decoded;
+    }
+
+    function decodeBER($bin) {
+        function my_unpack($format, &$bin, $length) {
+            $res = unpack($format, $bin);
+            $bin = substr($bin, $length);
+            return $res;
+        }
+
+        function readBER(&$bin) {
+            if(!strlen($bin)) return FALSE;
+
+            $data = my_unpack("C1type/c1length", $bin, 2);
+
+            if($data[length] < 0) {
+                $count = $data[length] & 0x7F;
+                $data[length] = 0;
+                while($count) {
+                    $data[length] <<= 8;
+                    $tmp = my_unpack("C1length", $bin, 1);
+                    $data[length] += $tmp[length];
+                    $count--;
+                }
+            }
+
+            switch($data[type]) {
+                case 0x30:
+                    $data[value] = array();
+                    do {
+                        $tmp = readBER($bin);
+                        if($tmp)
+                            $data[value][] = $tmp;
+                    } while($tmp);
+                    break;
+                case 0x03:
+                    $null = my_unpack("C1", $bin, 1);
+                    $data[value] = readBER($bin);
+                    break;
+                case 0x04:
+                    $data[value] = readBER($bin);
+                    break;
+                default: 
+                    $count = $data[length];
+                    while($count) {
+                        $tmp = my_unpack("C1data", $bin, 1);
+                        $data[value] .= sprintf("%02X", $tmp[data]);
+                        $count--;
+                    }
+            }
+            return $data;
+        }
+        return readBER($bin);
+    }
+
+    function getPublicKeyInfo($pubkey) {
+        function findKeyInfo($data, &$pubkeyinfo) {
+            if($data[type] == 48) {
+                if(count($data[value]) != 9) {
+                    foreach($data[value] as $subdata) {
+                        if(findKeyInfo($subdata, $pubkeyinfo))
+                            return true;
+                    }
+                } else {
+                    $pubkeyinfo = array(
+                        "modulus" => $data[value][1][value],
+                        "exponent" => $data[value][2][value],
+                    );
+                    return true;
+                }
+            }
+            elseif($data[type] == 4) {
+                return findKeyInfo($data[value], $pubkeyinfo);
+            }
+            return false;
+        }
+
+        $pubkey = preg_split("(-\n|\n-)", $pubkey);
+        $binary = base64_decode($pubkey[1]);
+        
+        $data = $this->decodeBER($binary);
+        
+        findKeyInfo($data, $pubkeyinfo);
+/*
+        $pubkeyinfo = array(
+            "modulus" => $data[value][1][value][2][value][value][1][value],
+            "exponent" => $data[value][1][value][2][value][value][2][value],
+        );
+*/
+        return $pubkeyinfo;
+    }
+
+    function workCorrect($yes = false) {
+        if($yes)
+            $this->_workCorrect = true;
+        return $this->_workCorrect;
+    }
 }

--- a/helper.php
+++ b/helper.php
@@ -204,7 +204,7 @@ class helper_plugin_securelogin extends DokuWiki_Plugin {
 			return false;
 		}
 
-		$pubkey = split("(-\n|\n-)", $pubkey);
+		$pubkey = preg_split("(-\n|\n-)", $pubkey);
 		$binary = base64_decode($pubkey[1]);
 		
 		$data = $this->decodeBER($binary);

--- a/helper.php
+++ b/helper.php
@@ -10,17 +10,17 @@ require_once(DOKU_INC.'inc/infoutils.php');
  * This is the base class for all syntax classes, providing some general stuff
  */
 class helper_plugin_securelogin extends DokuWiki_Plugin {
-	var $_keyFile;
-	var $_keyIFile;
-	var $_key = null;
-	var $_keyInfo = null;
-	var $_workCorrect = false;
-	var $_canWork = false;
+	protected $_keyFile;
+	protected $_keyIFile;
+	protected $_key = null;
+	protected $_keyInfo = null;
+	protected $_workCorrect = false;
+	protected $_canWork = false;
 	
 	/**
 	 * constructor
 	 */
-	function helper_plugin_securelogin(){
+	function __construct() {
 		global $conf;
 
 		$this->_keyIFile = $conf['cachedir'].'/securelogin.ini';

--- a/lang/cs/lang.php
+++ b/lang/cs/lang.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Securelogin Dokuwiki Plugin
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ */
 $lang['generate_key'] = 'Generovat nový pár klíčů';
 $lang['generate'] = 'Generovat';
 $lang['set'] = 'Nastavit';
@@ -13,4 +18,3 @@ $lang['use_securelogin'] = 'Bezpečné přihláčení';
 $lang['use_secureupdate'] = 'Použij bezpečný přenos hesla';
 $lang['securelogin_conf'] = 'Nastavení bezpečného přihlašování';
 $lang['sample_message'] = 'Toto je testovací zpráva';
-?>

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Securelogin Dokuwiki Plugin
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ */
 $lang['generate_key'] = 'Neues Schlüsselpaar generieren';
 $lang['generate'] = 'Generieren';
 $lang['set'] = 'Setzen';
@@ -13,4 +18,3 @@ $lang['use_securelogin'] = 'Sicheres Anmelden';
 $lang['use_secureupdate'] = 'Kennwort sicher übertragen';
 $lang['securelogin_conf'] = 'Secure login Konfiguration';
 $lang['sample_message'] = 'Das ist eine Testnachricht';
-?>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Securelogin Dokuwiki Plugin
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ */
 $lang['generate_key'] = 'Generate new key pair';
 $lang['generate'] = 'Generate';
 $lang['set'] = 'Set';
@@ -13,4 +18,3 @@ $lang['use_securelogin'] = 'Secure login';
 $lang['use_secureupdate'] = 'Use safe transfer of the password';
 $lang['securelogin_conf'] = 'Secure login configuration';
 $lang['sample_message'] = 'This is a test message';
-?>

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Securelogin Dokuwiki Plugin
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ */
 $lang['generate_key'] = 'Génération d\'un nouveau biclef';
 $lang['generate'] = 'Générer';
 $lang['set'] = 'Accepter';
@@ -13,4 +18,3 @@ $lang['use_securelogin'] = 'Connexion sécurisée';
 $lang['use_secureupdate'] = 'Envoi sécurisé du mot de passe';
 $lang['securelogin_conf'] = 'Connexions sécurisées';
 $lang['sample_message'] = 'Ceci est un message de test.';
-?>

--- a/lang/ja/lang.php
+++ b/lang/ja/lang.php
@@ -1,11 +1,10 @@
 <?php
- 
 /**
+ * Securelogin Dokuwiki Plugin
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * 
  * @author Hideaki SAWADA <chuno@live.jp>
  */
-
 $lang['generate_key'] = '新しい鍵ペアを生成します';
 $lang['generate'] = '新規キーの生成';
 $lang['set'] = '設定';

--- a/lang/ru/lang.php
+++ b/lang/ru/lang.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Securelogin Dokuwiki Plugin
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * 
+ */
 $lang['generate_key'] = 'Сгенерировать новую пару ключей';
 $lang['generate'] = 'Сгенерировать';
 $lang['set'] = 'Установить';
@@ -13,4 +18,3 @@ $lang['use_securelogin'] = 'Безопасный вход';
 $lang['use_secureupdate'] = 'Использовать защищённую передачу пароля';
 $lang['securelogin_conf'] = 'Настройки безопасного входа';
 $lang['sample_message'] = 'This is a test message';
-?>

--- a/script.js
+++ b/script.js
@@ -10,37 +10,37 @@
 var securelogin_forms = new Array();
 
 function securelogin_add_js(source) {
-	var jsNode = document.createElement('script');
-	jsNode.setAttribute('type', 'text/javascript');
-	jsNode.setAttribute('src', source);
-	document.getElementsByTagName('head')[0].appendChild(jsNode);
+    var jsNode = document.createElement('script');
+    jsNode.setAttribute('type', 'text/javascript');
+    jsNode.setAttribute('src', source);
+    document.getElementsByTagName('head')[0].appendChild(jsNode);
 }
 
 function securelogin_get_form(el) {
-	while(el && el.nodeName != 'FORM')
-		el = el.parentNode;
-	return el;
+    while(el && el.nodeName != 'FORM')
+        el = el.parentNode;
+    return el;
 }
 
 jQuery(function() {
-	var forms = new Array('dw__login', 'dw__register', 'test__publicKey', 'add_userid', 'modify_userid');
-	
-	var jsNeeded = false;
-	for (var i = 0; i < forms.length; ++i) {
-		var form = securelogin_get_form(jQuery("#" + forms[i])[0]);
-		if(!form) continue;
-		if(!jsNeeded)
-			jsNeeded = true;
-		var slNode = document.createElement('input');
-		slNode.setAttribute('type', 'hidden');
-		slNode.setAttribute('name', 'securelogin');
-		slNode.setAttribute('id', 'securelogin');
-		form.appendChild(slNode);
-		securelogin_forms.push(new Array(forms[i], form));
-	}
-	
-	if(jsNeeded) {
-		securelogin_add_js(DOKU_BASE+'lib/plugins/securelogin/rsalib.js');
-		securelogin_add_js(DOKU_BASE+'lib/plugins/securelogin/securelogin.js');
-	}
+    var forms = new Array('dw__login', 'dw__register', 'test__publicKey', 'add_userid', 'modify_userid');
+
+    var jsNeeded = false;
+    for (var i = 0; i < forms.length; ++i) {
+        var form = securelogin_get_form(jQuery("#" + forms[i])[0]);
+        if(!form) continue;
+        if(!jsNeeded)
+            jsNeeded = true;
+        var slNode = document.createElement('input');
+        slNode.setAttribute('type', 'hidden');
+        slNode.setAttribute('name', 'securelogin');
+        slNode.setAttribute('id', 'securelogin');
+        form.appendChild(slNode);
+        securelogin_forms.push(new Array(forms[i], form));
+    }
+
+    if(jsNeeded) {
+        securelogin_add_js(DOKU_BASE+'lib/plugins/securelogin/rsalib.js');
+        securelogin_add_js(DOKU_BASE+'lib/plugins/securelogin/securelogin.js');
+    }
 });

--- a/script.js
+++ b/script.js
@@ -1,3 +1,12 @@
+/**
+ * Securelogin Dokuwiki Plugin
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Mikhail I. Izmestev, Matt Bagley <securelogin@mattfiddles.com>
+ *
+ * @see also   https://www.dokuwiki.org/plugin:securelogin
+ */
+
 var securelogin_forms = new Array();
 
 function securelogin_add_js(source) {

--- a/securelogin.js
+++ b/securelogin.js
@@ -1,3 +1,12 @@
+/**
+ * Securelogin Dokuwiki Plugin
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Mikhail I. Izmestev, Matt Bagley <securelogin@mattfiddles.com>
+ *
+ * @see also   https://www.dokuwiki.org/plugin:securelogin
+ */
+
 function esc( x ) {
 	return encodeURIComponent(x);
 }

--- a/securelogin.js
+++ b/securelogin.js
@@ -8,124 +8,124 @@
  */
 
 function esc( x ) {
-	return encodeURIComponent(x);
+    return encodeURIComponent(x);
 }
 
 function secure_profile() {
-	var form = jQuery("#dw__register")[0];
-	if(!form || !form.use_securelogin.checked) return true;
-	var newpass = form.newpass;
-	var passchk = form.passchk;
-	var oldpass = form.oldpass;
-	var sectok = form.sectok;
-	
-	form.securelogin.value = encrypt("newpass="+esc(newpass.value)+"&passchk="+esc(passchk.value)+"&oldpass="+esc(oldpass.value)+";"+sectok.value);
-	oldpass.value = "******";
-	newpass.value = "******";
-	passchk.value = "******";
-	return true;
+    var form = jQuery("#dw__register")[0];
+    if(!form || !form.use_securelogin.checked) return true;
+    var newpass = form.newpass;
+    var passchk = form.passchk;
+    var oldpass = form.oldpass;
+    var sectok = form.sectok;
+
+    form.securelogin.value = encrypt("newpass="+esc(newpass.value)+"&passchk="+esc(passchk.value)+"&oldpass="+esc(oldpass.value)+";"+sectok.value);
+    oldpass.value = "******";
+    newpass.value = "******";
+    passchk.value = "******";
+    return true;
 }
 
 function secure_login() {
-	var form = jQuery("#dw__login")[0];
-	if(!form || !form.use_securelogin.checked) return true;
-	var user = form.u;
-	var pass = form.p;
-	var sectok = form.sectok;
-	
-	form.securelogin.value = encrypt("p="+esc(pass.value)+";"+sectok.value);
-	pass.value = "******";
-	return true;
+    var form = jQuery("#dw__login")[0];
+    if(!form || !form.use_securelogin.checked) return true;
+    var user = form.u;
+    var pass = form.p;
+    var sectok = form.sectok;
+
+    form.securelogin.value = encrypt("p="+esc(pass.value)+";"+sectok.value);
+    pass.value = "******";
+    return true;
 }
 
 function secure_admin() {
-	var el = jQuery("#test__message")[0];
-	if(el) 
-		el.value = encrypt(esc(el.value)); 
-	return true;					
+    var el = jQuery("#test__message")[0];
+    if(el) 
+        el.value = encrypt(esc(el.value)); 
+    return true;                    
 }
 
 function secure_add_user() {
-	var form = securelogin_get_form(jQuery('#add_userid')[0]);
-	if(!form || !form.use_securelogin.checked) return true;
-	var pass = form.add_userpass;
-	var sectok = form.sectok;
-	
-	form.securelogin.value = encrypt("userpass="+esc(pass.value)+";"+sectok.value);
-	pass.value = "******";
-	return true;
+    var form = securelogin_get_form(jQuery('#add_userid')[0]);
+    if(!form || !form.use_securelogin.checked) return true;
+    var pass = form.add_userpass;
+    var sectok = form.sectok;
+
+    form.securelogin.value = encrypt("userpass="+esc(pass.value)+";"+sectok.value);
+    pass.value = "******";
+    return true;
 }
 
 function secure_modify_user() {
-	var form = securelogin_get_form(jQuery('#modify_userid')[0]);
-	if(!form || !form.use_securelogin.checked) return true;
-	var pass = form.modify_userpass;
-	var sectok = form.sectok;
-	
-	form.securelogin.value = encrypt("userpass="+esc(pass.value)+";"+sectok.value);
-	pass.value = "******";
-	return true;
+    var form = securelogin_get_form(jQuery('#modify_userid')[0]);
+    if(!form || !form.use_securelogin.checked) return true;
+    var pass = form.modify_userpass;
+    var sectok = form.sectok;
+
+    form.securelogin.value = encrypt("userpass="+esc(pass.value)+";"+sectok.value);
+    pass.value = "******";
+    return true;
 }
 
 function ajaxSuccess(data) {
-		if(data === ''){ return; }
-		var jsNode = document.createElement('script');
-		jsNode.setAttribute('type', 'text/javascript');
-		jsNode.text = data;
-		document.getElementsByTagName('head')[0].appendChild(jsNode);
+        if(data === ''){ return; }
+        var jsNode = document.createElement('script');
+        jsNode.setAttribute('type', 'text/javascript');
+        jsNode.text = data;
+        document.getElementsByTagName('head')[0].appendChild(jsNode);
 
-		for(var i = 0; i < securelogin_forms.length; ++i) {
-			var form = securelogin_forms[i][1];
-			switch(securelogin_forms[i][0]) {
-			case 'dw__login':
-			case 'dw__register':
-				var uslNode = document.createElement('label');
-				var button = jQuery(":submit", form)[0];
-				if(!button) button = jQuery("input.button", form)[0];
-				button.parentNode.insertBefore(uslNode, button);
-				uslNode.setAttribute('class', 'simple');
-				uslNode.setAttribute('for', 'use_securelogin');
-				var label;
-				if('dw__login' == securelogin_forms[i][0]) {
-					jQuery(form).submit(secure_login);
-					label = securelogin_login_label;
-				}
-				else {
-					jQuery(form).submit(secure_profile);
-					label = securelogin_update_label;
-				}
-				uslNode.innerHTML = '<input type="checkbox" id="use_securelogin" name="use_securelogin" value="1" checked="checked"/> <span>'+label+'</span>';
-				break;
-			case 'test__publicKey':
-				jQuery(form).submit(secure_admin);
-				break;
-			case 'add_userid':
-			case 'modify_userid':
-				var uslNode = document.createElement('tbody');
-				var button = jQuery(":submit", form)[0].parentNode.parentNode.parentNode;
-				if(!button) button = jQuery("input.button", form)[0].parentNode.parentNode.parentNode;
-				button.parentNode.insertBefore(uslNode, button);
-				var tr = document.createElement('tr');
-				uslNode.appendChild(tr);
-				var td = document.createElement('td');
-				tr.appendChild(td);
-				td.innerHTML = '<label class="simple" for="use_securelogin">'+securelogin_update_label+'</label>';
-				td = document.createElement('td');
-				tr.appendChild(td);
-				td.innerHTML = '<input type="checkbox" id="use_securelogin" name="use_securelogin" value="1" checked="checked"/>';
-				if('add_userid' == securelogin_forms[i][0])
-					jQuery(form).submit(secure_add_user);
-				else
-					jQuery(form).submit(secure_modify_user);
-				break;
-			}
-		}
+        for(var i = 0; i < securelogin_forms.length; ++i) {
+            var form = securelogin_forms[i][1];
+            switch(securelogin_forms[i][0]) {
+            case 'dw__login':
+            case 'dw__register':
+                var uslNode = document.createElement('label');
+                var button = jQuery(":submit", form)[0];
+                if(!button) button = jQuery("input.button", form)[0];
+                button.parentNode.insertBefore(uslNode, button);
+                uslNode.setAttribute('class', 'simple');
+                uslNode.setAttribute('for', 'use_securelogin');
+                var label;
+                if('dw__login' == securelogin_forms[i][0]) {
+                    jQuery(form).submit(secure_login);
+                    label = securelogin_login_label;
+                }
+                else {
+                    jQuery(form).submit(secure_profile);
+                    label = securelogin_update_label;
+                }
+                uslNode.innerHTML = '<input type="checkbox" id="use_securelogin" name="use_securelogin" value="1" checked="checked"/> <span>'+label+'</span>';
+                break;
+            case 'test__publicKey':
+                jQuery(form).submit(secure_admin);
+                break;
+            case 'add_userid':
+            case 'modify_userid':
+                var uslNode = document.createElement('tbody');
+                var button = jQuery(":submit", form)[0].parentNode.parentNode.parentNode;
+                if(!button) button = jQuery("input.button", form)[0].parentNode.parentNode.parentNode;
+                button.parentNode.insertBefore(uslNode, button);
+                var tr = document.createElement('tr');
+                uslNode.appendChild(tr);
+                var td = document.createElement('td');
+                tr.appendChild(td);
+                td.innerHTML = '<label class="simple" for="use_securelogin">'+securelogin_update_label+'</label>';
+                td = document.createElement('td');
+                tr.appendChild(td);
+                td.innerHTML = '<input type="checkbox" id="use_securelogin" name="use_securelogin" value="1" checked="checked"/>';
+                if('add_userid' == securelogin_forms[i][0])
+                    jQuery(form).submit(secure_add_user);
+                else
+                    jQuery(form).submit(secure_modify_user);
+                break;
+            }
+        }
 }
 
 if(securelogin_forms) {
-	jQuery.post(
-		DOKU_BASE + 'lib/exe/ajax.php',
-		{ call: 'securelogin_public_key' },
-		ajaxSuccess
-	);
+    jQuery.post(
+        DOKU_BASE + 'lib/exe/ajax.php',
+        { call: 'securelogin_public_key' },
+        ajaxSuccess
+    );
 }

--- a/securelogin.js
+++ b/securelogin.js
@@ -71,7 +71,8 @@ function ajaxSuccess(data) {
 			case 'dw__login':
 			case 'dw__register':
 				var uslNode = document.createElement('label');
-				var button = jQuery("input.button", form)[0];
+				var button = jQuery(":submit", form)[0];
+				if(!button) button = jQuery("input.button", form)[0];
 				button.parentNode.insertBefore(uslNode, button);
 				uslNode.setAttribute('class', 'simple');
 				uslNode.setAttribute('for', 'use_securelogin');
@@ -92,7 +93,8 @@ function ajaxSuccess(data) {
 			case 'add_userid':
 			case 'modify_userid':
 				var uslNode = document.createElement('tbody');
-				var button = jQuery("input.button", form)[0].parentNode.parentNode.parentNode;
+				var button = jQuery(":submit", form)[0].parentNode.parentNode.parentNode;
+				if(!button) button = jQuery("input.button", form)[0].parentNode.parentNode.parentNode;
 				button.parentNode.insertBefore(uslNode, button);
 				var tr = document.createElement('tr');
 				uslNode.appendChild(tr);


### PR DESCRIPTION
Since DokuWIki Release 2015-08-10 "Detritus", all `<input type=submit />` buttons have changed to `<button type=submit></button>` button. It causes javascript error and securelogin does not work. This PR contains javascript correction for the change, see 104b51234e277def40d021b2530ea69629f4d177

I also tried to make plugin code PHP5 standard and to follow DokuWiki coding guidance.
